### PR TITLE
UTF16 Parser Fails Gracefully

### DIFF
--- a/MarkdownKit/Classes/Extensions/String+UTF16.swift
+++ b/MarkdownKit/Classes/Extensions/String+UTF16.swift
@@ -24,11 +24,13 @@ extension String {
     var utf16Array = [UInt16]()
     stride(from: 0, to: characters.count, by: 4).forEach {
       let startIndex = characters.index(characters.startIndex, offsetBy: $0)
-      let endIndex = characters.index(characters.startIndex, offsetBy: $0 + 4)
-      let hex4 = substring(with: startIndex..<endIndex)
-      
-      if let utf16 = UInt16(hex4, radix: 16) {
-        utf16Array.append(utf16)
+      if ($0 + 4) < characters.count {
+        let endIndex = characters.index(characters.startIndex, offsetBy: $0 + 4)
+        let hex4 = substring(with: startIndex..<endIndex)
+            
+        if let utf16 = UInt16(hex4, radix: 16) {
+          utf16Array.append(utf16)
+        }
       }
     }
     


### PR DESCRIPTION
- The current implementation crashes if characters.count is not a
factor of 4
- Once could make the argument that a UTF16 string should always work
with this method but an application should not crash if a bad markdown
string is passed to it
- This implementation fails gracefully, continues through the loop, and
drops any bad markdown in the UTF16 string